### PR TITLE
feat: add no-console rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
         camelcase: ['error', { properties: 'never' }],
         'dot-notation': 'error',
         eqeqeq: 'error',
-        "no-console": 2,
+        "no-console": 'error',
         'no-duplicate-imports': 'error',
         'no-nested-ternary': 'error',
         'no-useless-computed-key': 'error',

--- a/index.js
+++ b/index.js
@@ -24,6 +24,12 @@ module.exports = {
         camelcase: ['error', { properties: 'never' }],
         'dot-notation': 'error',
         eqeqeq: 'error',
+        "no-console": [
+            2,
+            {
+                "allow": ["warn"]
+            }
+        ],
         'no-duplicate-imports': 'error',
         'no-nested-ternary': 'error',
         'no-useless-computed-key': 'error',

--- a/index.js
+++ b/index.js
@@ -24,12 +24,7 @@ module.exports = {
         camelcase: ['error', { properties: 'never' }],
         'dot-notation': 'error',
         eqeqeq: 'error',
-        "no-console": [
-            2,
-            {
-                "allow": ["warn"]
-            }
-        ],
+        "no-console": 2,
         'no-duplicate-imports': 'error',
         'no-nested-ternary': 'error',
         'no-useless-computed-key': 'error',


### PR DESCRIPTION
Add rule to not allow console logs so that they are not accidentally left in the code.

## Reasoning
From https://eslint.org/docs/2.0.0/rules/no-console:
> In JavaScript that is designed to be executed in the browser, it’s considered a best practice to avoid using methods on console. Such messages are considered to be for debugging purposes and therefore not suitable to ship to the client. In general, calls using console should be stripped before being pushed to production.
