### PR TITLE
feat: enforce import sorting

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,5 +30,6 @@ module.exports = {
         'no-var': 'error',
         'prefer-const': 'error',
         'prefer-template': 'error',
+        'sort-imports': 'error',
     },
 }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,6 +1,6 @@
-import prettierRules from 'eslint-config-prettier'
-import prettierReactRules from 'eslint-config-prettier/react'
 import { CLIEngine } from 'eslint'
+import prettierReactRules from 'eslint-config-prettier/react'
+import prettierRules from 'eslint-config-prettier'
 
 const allPrettierRules = Object.keys(prettierRules.rules).concat(
     Object.keys(prettierReactRules.rules),


### PR DESCRIPTION
BREAKING CHANGE: Updating to the new version (assuming this is merged) will cause significant changes in consumers of the package. Those changes should be cosmetic, but will still likely produce a significant number of changes

Based on discussions internally, a lot of PR comments were being posted about import sorting, or member sorting, and those are the types of bikeshedding we don't want to deal with. Even if we're not 100% happy with the results of the automatic sorting, it's better than having to add comments to every PR about sorting.
