### PR TITLE
fix: remove buggy require-atomic-updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
         'no-var': 'error',
         'prefer-const': 'error',
         'prefer-template': 'error',
+        /* require-atomic-updates broken per https://github.com/eslint/eslint/issues/11899 */
         'require-atomic-updates': 'off',
         'sort-imports': 'error',
     },

--- a/index.js
+++ b/index.js
@@ -30,5 +30,6 @@ module.exports = {
         'no-var': 'error',
         'prefer-const': 'error',
         'prefer-template': 'error',
+        'require-atomic-updates': 'off',
     },
 }


### PR DESCRIPTION
Removes `require-atomic-updates`.

Information on the rule: https://eslint.org/docs/rules/require-atomic-updates

I propose removing `require-atomic-updates` as it produces too many false positives such that it can't be used reliably. If we can't rely on this rule correctly identifying problematic cases, it does more harm than good by creating confusion.

Discussion around the known issues: https://github.com/eslint/eslint/issues/11899

We should only re-enable this rule once it has been fixed in the official eslint repository.

---

Latest update from eslint, they're removing the rule in a minor release from eslint recommended: https://github.com/eslint/tsc-meetings/blob/master/notes/2019/2019-10-10.md#require-atomic-updates-false-positive