### PR TITLE
feat: Add base config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,27 @@
 
 ## Usage
 
-### Base config
+The default config includes a set of base rules, rules for React apps, and rules for Jest tests. Extend the default config by first installing all the required dependencies:
 
-```
-yarn add --dev @tophat/eslint-config eslint prettier eslint-config-prettier eslint-plugin-prettier
+```bash
+yarn add --dev \
+    @tophat/eslint-config \
+    eslint \
+    prettier \
+    eslint-config-prettier \
+    eslint-plugin-prettier \
+    eslint-plugin-react \
+    eslint-plugin-jsx-a11y \
+    eslint-plugin-jest
 ```
 
 or
 
-```
-npm install --save-dev @tophat/eslint-config eslint prettier eslint-config-prettier eslint-plugin-prettier
+```bash
+npm install --save-dev # ...
 ```
 
-In your eslint config (for example .eslintrc.js):
+Then update your eslint config (for example, .eslintrc.js):
 
 ```javascript
 module.exports = {
@@ -29,39 +37,32 @@ module.exports = {
 }
 ```
 
-### React config
+## Picking and choosing certain configs
 
-If you are using React in your project, you can install the relevant plugins:
-
-```
-yarn add --dev eslint-plugin-react eslint-plugin-jsx-a11y # or npm install --save-dev ...
-```
-
-and extend the React configuration as well:
+You can extend each of the configs separately by specifying them in your eslint config:
 
 ```javascript
 module.exports = {
-    extends: ['@tophat', '@tophat/eslint-config/react']
+    extends: [
+        // Pick and choose from the following list of configs
+        '@tophat/eslint-config/base',
+        '@tophat/eslint-config/react',
+        '@tophat/eslint-config/jest',
+    ]
 }
 ```
 
-### Jest config
+## Peer dependencies per config
 
-Similarly for jest, you can install the relevant plugins:
+Each config requires certain peer dependencies:
 
-```
-yarn add --dev eslint-plugin-jest # or npm install --save-dev ...
-```
+- **base**: eslint, prettier, eslint-config-prettier, eslint-plugin-prettier
+- **react**: eslint-plugin-react, eslint-plugin-jsx-a11y
+- **jest**: eslint-plugin-jest
 
-and extend the Jest configuration:
+You only have to install the dependencies for the configs which you are using.
 
-```javascript
-module.exports = {
-    extends: ['@tophat', '@tophat/eslint-config/jest']
-}
-```
-
-## Making changes to this config
+## Making changes to this package
 
 This eslint config is for Top Hat's open source and internal use, so we generally won't be accepting external contributions.
 If you are an external contributor and you have a rule that you really feel should be included in our global config, feel free to make a suggestion, but please don't take it personally if we decide not to adopt the rule.

--- a/base.js
+++ b/base.js
@@ -1,0 +1,33 @@
+module.exports = {
+    env: {
+        node: true,
+        browser: true,
+        es6: true,
+    },
+    extends: ['eslint:recommended', 'prettier'],
+    plugins: ['prettier'],
+    rules: {
+        'prettier/prettier': [
+            'error',
+            {
+                printWidth: 80,
+                tabWidth: 4,
+                semi: false,
+                trailingComma: 'all',
+                singleQuote: true,
+            },
+        ],
+        camelcase: ['error', { properties: 'never' }],
+        'dot-notation': 'error',
+        eqeqeq: 'error',
+        'no-duplicate-imports': 'error',
+        'no-nested-ternary': 'error',
+        'no-useless-computed-key': 'error',
+        'no-var': 'error',
+        'prefer-const': 'error',
+        'prefer-template': 'error',
+        /* require-atomic-updates broken per https://github.com/eslint/eslint/issues/11899 */
+        'require-atomic-updates': 'off',
+        'sort-imports': 'error',
+    },
+}

--- a/index.js
+++ b/index.js
@@ -4,4 +4,5 @@ module.exports = {
         ecmaVersion: 9,
         sourceType: 'module',
     },
+    rules: {},
 }

--- a/index.js
+++ b/index.js
@@ -1,37 +1,7 @@
 module.exports = {
+    extends: ['./base', './react', './jest'].map(require.resolve),
     parserOptions: {
         ecmaVersion: 9,
         sourceType: 'module',
-    },
-    env: {
-        node: true,
-        browser: true,
-        es6: true,
-    },
-    extends: ['eslint:recommended', 'prettier'],
-    plugins: ['prettier'],
-    rules: {
-        'prettier/prettier': [
-            'error',
-            {
-                printWidth: 80,
-                tabWidth: 4,
-                semi: false,
-                trailingComma: 'all',
-                singleQuote: true,
-            },
-        ],
-        camelcase: ['error', { properties: 'never' }],
-        'dot-notation': 'error',
-        eqeqeq: 'error',
-        'no-duplicate-imports': 'error',
-        'no-nested-ternary': 'error',
-        'no-useless-computed-key': 'error',
-        'no-var': 'error',
-        'prefer-const': 'error',
-        'prefer-template': 'error',
-        /* require-atomic-updates broken per https://github.com/eslint/eslint/issues/11899 */
-        'require-atomic-updates': 'off',
-        'sort-imports': 'error',
     },
 }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -15,6 +15,13 @@ const configs = [
 `,
     },
     {
+        file: 'base.js',
+        codeExample: `export default function(a, b) {
+    return a + b
+}
+`,
+    },
+    {
         file: 'react.js',
         codeExample: `
 var React = require('react')

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -16,9 +16,11 @@ const configs = [
     },
     {
         file: 'base.js',
-        codeExample: `export default function(a, b) {
+        codeExample: `function foo(a, b) {
     return a + b
 }
+
+foo(1, 2)
 `,
     },
     {


### PR DESCRIPTION
Moves the default config to a config called `base` and updates the default config to include `base`, `react`, and `jest`.

Definitely a breaking change.

Some guidance drawn from the much-lauded Airbnb config: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/index.js