### PR TITLE
feat: Move parser options back to base config

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,4 +1,8 @@
 module.exports = {
+    parserOptions: {
+        ecmaVersion: 9,
+        sourceType: 'module',
+    },
     env: {
         node: true,
         es6: true,

--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
 module.exports = {
     extends: ['./base', './react', './jest', './web'].map(require.resolve),
-    parserOptions: {
-        ecmaVersion: 9,
-        sourceType: 'module',
-    },
     rules: {},
 }


### PR DESCRIPTION
This was initially moved in https://github.com/tophat/eslint-config/pull/38 when the base config was created. After playing around with the published version, I realized the prettier config specifies trailing commas everywhere, which mandates a minimum ecmaVersion of 9, so it makes sense to specify parserOptions in base config. RETURN HOME MY WAYWARD SON.

A BREAKING CHANGE, technically.