### PR TITLE
feat: remove exports-last-rule

### DIFF
--- a/base.js
+++ b/base.js
@@ -35,7 +35,6 @@ module.exports = {
         'sort-imports': ['error', { ignoreDeclarationSort: true }],
         'import/default': 'error',
         'import/export': 'error',
-        'import/exports-last': 'error',
         'import/named': 'error',
         'import/newline-after-import': 'error',
         'import/no-absolute-path': 'error',


### PR DESCRIPTION
I didn't try this one out, and I immediately hate it. Let's look at a few use cases why this sucks:
#### Selector Files
```js
export const selector1 = () => {}
const internal selector2 = () => {}
export const selector3 = state => { selector2(state).get('something_else') }
```
This is a really common pattern of "internal selectors" to help save some duplication for public selectors. In a small file it's fine to put at the top, but in a file of 50+ selectors it makes sense to colocate your internal selector with the selectors that use it.

#### Connected Components
```js
export class UnconnectedComponent {}
const mapStateToProps = {}
const mapDispatchToProps = {}
export default connect(unconnectedComponent)
```
This is a SUPER common example. To resolve this rule, we have to move `mapStateToProps` and `mapDispatchToProps` to the top (which will be annoying to do without an auto fixer), or move Unconnected export down to join the default export and leave the component where it is(again, annoying)

#### Helper Functions
```js
export function helper1() {}
function internalHelper2() {}
export function helper3() { return internalHelper2().toString() }
```
This is similar to the selectors issue. It makes sense to colocate things together in larger files. 

Overall this was an oversight on my part to not try out this rule. I mostly viewed it as helping with duck index files, which define the public API. I think in practice, this rule will make it harder to understand our code than the benefit it provides.