### PR TITLE
fix: don't fail jest expect when using redux test plan

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -8,5 +8,9 @@ module.exports = {
         'jest/prefer-to-be-null': 'error',
         'jest/prefer-to-be-undefined': 'error',
         'jest/prefer-to-have-length': 'error',
+        'jest/expect-expect': [
+            'error',
+            { assertFunctionNames: ['expect', 'testSaga', 'expectSaga'] },
+        ],
     },
 }


### PR DESCRIPTION
When using redux saga test plan, these two patterns are common:

```javascript
it('does something', () => {
    testSaga(mySaga).run()
})

it('does something', () => expectSaga(mySaga).run())
```

Currently this raises "Test has no assertion" warnings via `jest/expect-expect`. I'm proposing adding function name exceptions via: https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/expect-expect.md.