### PR TITLE
feat: Add quotes rule

### DIFF
--- a/base.js
+++ b/base.js
@@ -29,6 +29,7 @@ module.exports = {
         'no-var': 'error',
         'prefer-const': 'error',
         'prefer-template': 'error',
+        quotes: ['error', 'single', { avoidEscape: true }],
         /* require-atomic-updates broken per https://github.com/eslint/eslint/issues/11899 */
         'require-atomic-updates': 'off',
         // no autofixer on declaration sort of sort-imports, so we use import/order for declaration sort

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -66,7 +66,12 @@ configs.forEach(({ file, codeExample }) => {
 
     describe(`${file} config`, () => {
         it("doesn't include any rules superseded by prettier", () => {
-            const baseRules = Object.keys(config.rules)
+            const prettierConflictWhitelist = ['quotes']
+
+            const baseRules = Object.keys(config.rules).filter(
+                rule => !prettierConflictWhitelist.includes(rule),
+            )
+
             baseRules.forEach(baseRule => {
                 expect(allPrettierRules).not.toContain(baseRule)
             })


### PR DESCRIPTION
This rule complements the prettier quotes option by disallowing unnecessary template strings:

```js
// BAD:
const x = `dont need template here`
```

```js
// GOOD:
const x = 'nice, no template needed'
const y = `also ${1 + 1} ok bc I need template`
const z = `so okay
because i like
multilines baby`
```

Using template strings only when actual interpolation or multiline is needed makes it clearer what the code is doing: no backticks, no interpolation, just take the string for what it is. Otherwise it's not immediately clear whether or not a back-ticked string will have interpolation in it (especially for some longer strings), and therefore whether or not it can be moved around easily.