### PR TITLE
fix: Update config to support prettier@2

### DIFF
--- a/base.js
+++ b/base.js
@@ -18,6 +18,7 @@ module.exports = {
                 semi: false,
                 trailingComma: 'all',
                 singleQuote: true,
+                arrowParens: 'avoid',
             },
         ],
         camelcase: ['error', { properties: 'never' }],

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^2.5.1",
     "jest": "^25.1.0",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.1"
   }
 }

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -11,7 +11,7 @@ const allPrettierRules = Object.keys(prettierRules.rules).concat(
 const configs = [
     {
         file: 'index.js',
-        codeExample: `export default function(a, b) {
+        codeExample: `export default function (a, b) {
     return a + b
 }
 `,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,10 +3758,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.1.tgz#3f00ac71263be34684b2b2c8d7e7f63737592dac"
+  integrity sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==
 
 pretty-format@^25.1.0:
   version "25.1.0"


### PR DESCRIPTION
See https://prettier.io/blog/2020/03/21/2.0.0.html for details. We are still compatible for the >= 1.0.0 range.