### PR TITLE
feat: delete deprecated rule and add replacement rule

### DIFF
--- a/react.js
+++ b/react.js
@@ -8,7 +8,7 @@ module.exports = {
     extends: ['plugin:react/recommended', 'prettier/react'],
     rules: {
         'jsx-a11y/aria-props': 'error',
-        'jsx-a11y/label-has-for': 'error',
+        'jsx-a11y/label-has-associated-control': 'error',
         'jsx-a11y/mouse-events-have-key-events': 'error',
         'jsx-a11y/role-has-required-aria-props': 'error',
         'jsx-a11y/role-supports-aria-props': 'error',


### PR DESCRIPTION
The rule `jsx-a11y/label-has-for` [was deprecated](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) and replaced by `jsx-a11y/label-has-associated-control` which is a more lenient version of the deprecated rule.

This will not cause any new errors because everything enforced by `label-has-associated-control` was already being enforced by `label-has-for`. Therefore it only requires a minor version bump