### PR TITLE
feat: Always use arrow parens to make migration to typescript simpler

### DIFF
--- a/base.js
+++ b/base.js
@@ -18,7 +18,7 @@ module.exports = {
                 semi: false,
                 trailingComma: 'all',
                 singleQuote: true,
-                arrowParens: 'avoid',
+                arrowParens: 'always',
             },
         ],
         camelcase: ['error', { properties: 'never' }],

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -92,7 +92,7 @@ ReactDOM.render(React.createElement('div'), element)
     },
 ]
 
-configs.forEach(params => {
+configs.forEach((params) => {
     const { file, codeExample, badCodeMessageCount, badCodeExample } = params
     const config = require(`../${file}`)
 
@@ -101,10 +101,10 @@ configs.forEach(params => {
             const prettierConflictWhitelist = ['quotes']
 
             const baseRules = Object.keys(config.rules).filter(
-                rule => !prettierConflictWhitelist.includes(rule),
+                (rule) => !prettierConflictWhitelist.includes(rule),
             )
 
-            baseRules.forEach(baseRule => {
+            baseRules.forEach((baseRule) => {
                 expect(allPrettierRules).not.toContain(baseRule)
             })
         })


### PR DESCRIPTION
Based on a recent discussion about expanding support for typescript, always using parentheses on arrow functions would make adding type notations simpler.