### PR TITLE
fix: specify to use custom tophat resolver before node

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -157,12 +157,14 @@ module.exports = {
         'import/parsers': {
             '@typescript-eslint/parser': ['.ts', '.tsx', '.js', '.jsx'],
         },
-        'import/resolver': {
-            typescript: {
-                alwaysTryTypes: true,
+        'import/resolver': [
+            {
+                typescript: {
+                    alwaysTryTypes: true,
+                },
             },
-            node: {},
-            ...(importResolverRequire ? { [importResolverRequire]: {} } : {}),
-        },
+            { ...(importResolverRequire ? { [importResolverRequire]: {} } : {}), },
+            { node: {}, },
+        ]
     },
 }

--- a/base/index.js
+++ b/base/index.js
@@ -163,11 +163,9 @@ module.exports = {
                     alwaysTryTypes: true,
                 },
             },
-            {
-                ...(importResolverRequire
-                    ? [{ [importResolverRequire]: {} }]
-                    : []),
-            },
+            ...(importResolverRequire
+                ? [{ [importResolverRequire]: {} }]
+                : []),
             { node: {} },
         ],
     },

--- a/base/index.js
+++ b/base/index.js
@@ -163,9 +163,7 @@ module.exports = {
                     alwaysTryTypes: true,
                 },
             },
-            ...(importResolverRequire
-                ? [{ [importResolverRequire]: {} }]
-                : []),
+            ...(importResolverRequire ? [{ [importResolverRequire]: {} }] : []),
             { node: {} },
         ],
     },

--- a/base/index.js
+++ b/base/index.js
@@ -165,8 +165,8 @@ module.exports = {
             },
             {
                 ...(importResolverRequire
-                    ? { [importResolverRequire]: {} }
-                    : {}),
+                    ? [{ [importResolverRequire]: {} }]
+                    : []),
             },
             { node: {} },
         ],

--- a/base/index.js
+++ b/base/index.js
@@ -163,8 +163,12 @@ module.exports = {
                     alwaysTryTypes: true,
                 },
             },
-            { ...(importResolverRequire ? { [importResolverRequire]: {} } : {}), },
-            { node: {}, },
-        ]
+            {
+                ...(importResolverRequire
+                    ? { [importResolverRequire]: {} }
+                    : {}),
+            },
+            { node: {} },
+        ],
     },
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "test": "jest --config jest.config.js",
     "lint": "eslint . --max-warnings 0",
+    "lint-fix": "eslint . --fix",
     "test:ci": "run test",
     "lint:ci": "run lint"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:ci": "run lint"
   },
   "peerDependencies": {
-    "@tophat/eslint-import-resolver-require": ">=0.1.2",
+    "@tophat/eslint-import-resolver-require": ">=0.1.3",
     "@typescript-eslint/eslint-plugin": ">=4.27.0",
     "@typescript-eslint/parser": ">=4.27.0",
     "eslint": ">=7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,7 +1884,7 @@ __metadata:
     prettier: ^2.3.1
     typescript: ~4.3.2
   peerDependencies:
-    "@tophat/eslint-import-resolver-require": ">=0.1.2"
+    "@tophat/eslint-import-resolver-require": ">=0.1.3"
     "@typescript-eslint/eslint-plugin": ">=4.27.0"
     "@typescript-eslint/parser": ">=4.27.0"
     eslint: ">=7.0.0"


### PR DESCRIPTION
If you use an array for the resolver, it will go in the specified order of the array. This moves our custom resolver (which works better with yarn 2) over the default node resolver. 

Also updates the peer dependency on our custom resolver to the version that handles virtual sibling packages correctly.