### PR TITLE
fix: Prevent tslint and prettier from fighting over semi-colons

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -134,6 +134,7 @@ module.exports = {
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
+        // prettier must be the last item in this list to prevent conflicts
         'prettier',
     ],
     plugins: ['import', 'prettier', '@typescript-eslint'],

--- a/base/index.js
+++ b/base/index.js
@@ -133,8 +133,8 @@ module.exports = {
     },
     extends: [
         'eslint:recommended',
-        'prettier',
         'plugin:@typescript-eslint/recommended',
+        'plugin:prettier/recommended',
     ],
     plugins: ['import', 'prettier', '@typescript-eslint'],
     rules,

--- a/base/index.js
+++ b/base/index.js
@@ -134,7 +134,7 @@ module.exports = {
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
-        'plugin:prettier/recommended',
+        'prettier',
     ],
     plugins: ['import', 'prettier', '@typescript-eslint'],
     rules,


### PR DESCRIPTION
`@typescript-eslint/no-extra-semi` conflicts with prettiers opinion on how/where semi colons should be placed. For example, this is irreconcilable:
```js
;(async () => {
    return 1
})().then((code) => process.exit(code))
```
prettier insists that a semi-colon is present, and @typescript-eslint/no-extra-semi insists one is not. If you have formatting on save set up, you will actually see each one win on every other save.

Prettier provides a configuration to turn off all the rules it disagrees with, which we use, but that config **must** be the last item in the list, to ensure all the previous rules are turned off correctly. When we added typescript support, it was added below the prettier config. This restores the correct order and should prevent the problem.