### PR TITLE
fix: Exclude functions from no-use-before-define rule

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -102,7 +102,7 @@ const rules = {
     // no-use-before-define can cause errors with typescript concepts, like types or enums
     'no-use-before-define': 'off',
     // functions can be called before they are defined because function declarations are hoisted
-    '@typescript-eslint/no-use-before-define': ['error', { "functions": true }],
+    '@typescript-eslint/no-use-before-define': ['error', { functions: true }],
 }
 
 const jsIncompatibleRules = {

--- a/base/index.js
+++ b/base/index.js
@@ -101,7 +101,8 @@ const rules = {
 
     // no-use-before-define can cause errors with typescript concepts, like types or enums
     'no-use-before-define': 'off',
-    '@typescript-eslint/no-use-before-define': 'error',
+    // functions can be called before they are defined because function declarations are hoisted
+    '@typescript-eslint/no-use-before-define': ['error', { "functions": true }],
 }
 
 const jsIncompatibleRules = {


### PR DESCRIPTION
Functions can still be used before they are defined, the issue is largely with variables and classes not in ES6. 