### PR TITLE
feat: Alphabetize imports by import location

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -90,6 +90,7 @@ const rules = {
                 'sibling',
                 'index',
             ],
+            alphabetize: { order: 'asc' },
         },
     ],
 

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
       "optional": true
     }
   },
+  "resolutions": {
+    "@yarnpkg/plugin-compat": "npm:@yarnpkg/plugin-compat@3.1.2-rc.1"
+  },
   "packageManager": "yarn@3.1.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2475,13 +2475,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-compat@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "@yarnpkg/plugin-compat@npm:3.1.1"
+"@yarnpkg/plugin-compat@npm:@yarnpkg/plugin-compat@3.1.2-rc.1":
+  version: 3.1.2-rc.1
+  resolution: "@yarnpkg/plugin-compat@npm:3.1.2-rc.1"
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0
-    "@yarnpkg/plugin-patch": ^3.1.0
-  checksum: 698d58ff96c8ceb870afa897158e542d340404f9f2b87d129f1467f8e2ae33ddae16824dafb61b49290c21ade8b7f94dbc634907b365e65f4c35f939eabd631c
+    "@yarnpkg/core": ^3.2.0-rc.5
+    "@yarnpkg/plugin-patch": ^3.1.1-rc.3
+  checksum: 2a1fe6c96995a3e62e5930e81c35232d99531c41c3936f44e1228d4f2f7312bc8ac50a68adb11406c17834baace74ab3641e47e99a6bea4d8296a561549cb00d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8537,11 +8537,11 @@ resolve@^2.0.0-next.3:
 
 "typescript@patch:typescript@~4.5.2#~builtin<compat/typescript>":
   version: 4.5.2
-  resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=ddd1e8"
+  resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 24a439e062a05e3285a4f0e8a40644116ecdca89f3e908bed01e5a01b9aee747e3bcf0e85fe9e017e5ebf0c0863437c39479f2616f55a244c2d82d37022cdc4f
+  checksum: 53838d56aba6fcc947d63aa0771e5d966b1b648fddafed6e221d7f38c71219c4e036ece8cfe9e35ed80cf5a35ff4eb958934c993f99c3233773ec4f9ccd53f69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
BREAKING CHANGE: You will need to run `eslint --fix .` on your code base when adopting this update and it will sort all imports in your codebase. After this change, there will be a single correct order for all imports with an auto-fixing rule to correct them.

https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#alphabetize-order-ascdescignore-caseinsensitive-truefalse