### PR TITLE
feat(react): use default arguments for function components

### DIFF
--- a/react/index.js
+++ b/react/index.js
@@ -17,6 +17,7 @@ module.exports = {
             'error',
             {
                 forbidDefaultForRequired: true,
+                functions: 'defaultArguments',
             },
         ],
         'react/display-name': 'off',


### PR DESCRIPTION
https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md#functions

So we can use function defaults instead of requiring the static defaultProps.