### PR TITLE
feat: Expand list of typescript rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,10 @@
 module.exports = {
     ...require('./index'),
-    ignorePatterns: ['/.yarn', '/.git', '/.github', '/.vscode', '/artifacts'],
+    ignorePatterns: ['/.yarn', '/.git', '/.github', '/.vscode', '/artifacts', '.eslintrc.js'],
+    parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        tsconfigRootDir: __dirname,
+        project: ['./tsconfig.json'],
+    },
 }

--- a/base/index.js
+++ b/base/index.js
@@ -122,6 +122,16 @@ const rules = {
         'error',
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
     ],
+    '@typescript-eslint/no-confusing-void-expression': 'warn',
+    '@typescript-eslint/no-duplicate-enum-values': 'warn',
+    '@typescript-eslint/no-for-in-array': 'error',
+    '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',
+    '@typescript-eslint/prefer-includes': 'warn',
+    '@typescript-eslint/prefer-for-of': 'warn',
+    '@typescript-eslint/prefer-optional-chain': 'warn',
+    '@typescript-eslint/prefer-reduce-type-parameter': 'warn',
+    '@typescript-eslint/prefer-string-starts-ends-with': 'warn',
+    '@typescript-eslint/prefer-ts-expect-error': 'error',
 
     // no-use-before-define can cause errors with typescript concepts, like types or enums
     'no-use-before-define': 'off',

--- a/base/index.js
+++ b/base/index.js
@@ -122,7 +122,10 @@ const rules = {
         'error',
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
     ],
-    '@typescript-eslint/no-confusing-void-expression': 'warn',
+    '@typescript-eslint/no-confusing-void-expression': [
+        'warn',
+        { ignoreVoidOperator: true },
+    ],
     '@typescript-eslint/no-duplicate-enum-values': 'warn',
     '@typescript-eslint/no-for-in-array': 'error',
     '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -95,6 +95,11 @@ describe.each(configs)(
         let config
         beforeAll(() => {
             config = require(`../${file}`)
+            config.parserOptions = {
+                ...config.parserOptions,
+                tsconfigRootDir: '.',
+                project: ['./tsconfig.json'],
+            }
         })
         afterAll(() => {
             config = null
@@ -120,7 +125,7 @@ describe.each(configs)(
                 overrideConfigFile: file,
             })
             const results = await cli.lintText(codeExample, {
-                filePath: 'example/file.js',
+                filePath: 'tests/example.js',
             })
             expect(results[0].messages).toEqual([])
         })
@@ -136,7 +141,7 @@ describe.each(configs)(
                 overrideConfigFile: file,
             })
             const results = await cli.lintText(badCodeExample, {
-                filePath: 'example/file.js',
+                filePath: 'tests/example.js',
             })
             expect(results[0].messages).toHaveLength(badCodeMessageCount)
         })

--- a/tests/example.js
+++ b/tests/example.js
@@ -1,0 +1,1 @@
+// leave this file here, it's used for testing

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "noImplicitAny": true,
+        "moduleResolution": "node",
+        "module": "NodeNext",
+        "allowJs": true,
+        "noEmit": true,
+        "strict": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "lib": ["esnext"]
+    },
+    "exclude": [".eslintrc.js"]
+}


### PR DESCRIPTION
BREAKING CHANGE: We are expanding your list of typescript rules which requires connecting your eslint config to your tsconfig. See the typescript-eslint documentation https://typescript-eslint.io/linting/typed-linting for how to do this. If your project does not use typescript and you do not want to add a tsconfig file needlessly, disable the following rules in your config: @typescript-eslint/no-confusing-void-expression, @typescript-eslint/no-for-in-array, @typescript-eslint/prefer-includes, @typescript-eslint/prefer-reduce-type-parameter, and @typescript-eslint/prefer-string-starts-ends-with.