### PR TITLE
fix: disable react/jsx-no-leaked-render in TypeScript components

### DIFF
--- a/react/index.js
+++ b/react/index.js
@@ -43,6 +43,14 @@ if (reactModule) {
             'react/jsx-props-no-spreading': 'off',
         },
     })
+    overrides.push({
+        files: ['*.tsx'],
+        rules: {
+            // In TypeScript, we know with certainty whether we're using booleans or some condition
+            // that may shortcircuit and return undefined.
+            'react/jsx-no-leaked-render': 'off',
+        },
+    })
 }
 
 const reactHooksModule = doesModuleExist('eslint-plugin-react-hooks')


### PR DESCRIPTION
In TypeScript components, we know with certainty when a condition might shortcircuit and return undefined and thus cause React to crash.

From the docs for the rule https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md#when-not-to-use-it:

> When Not To Use It
> If you are working in a typed-codebase which encourages you to always use boolean conditions, this rule can be disabled.