### PR TITLE
feat: adopt recommended config for tanstack eslint-plugin-query

### DIFF
--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -73,10 +73,7 @@ if (jsxA11yModule) {
 const tanstackQueryModule = doesModuleExist('@tanstack/eslint-plugin-query')
 if (tanstackQueryModule) {
     plugins.push('@tanstack/query')
-    Object.assign(rules, {
-        '@tanstack/query/exhaustive-deps': 'error',
-        '@tanstack/query/prefer-query-object-syntax': 'warn',
-    })
+    extensions.push('plugin:@tanstack/eslint-plugin-query/recommended')
 }
 
 const config: ESLint.ConfigData = {


### PR DESCRIPTION
BREAKING CHANGE: Since we are setting the @tanstack/query/prefer-query-object-syntax, this will require changes to your code that satisfy the rule before CI will pass. You will no longer be able to skip these changes.

--- 

This PR adopts the recommended config for tanstack eslint-plugin-query. The recommended config configures all rules in eslint-plugin-query as errors. In particular, we are now requiring object syntax by setting the `"@tanstack/query/prefer-query-object-syntax"` rule to `error`. `@tanstack/query/exhaustive-deps` was already set to error.