### PR TITLE
feat: adopt recommended config for tanstack eslint-plugin-query

### DIFF
--- a/config/package.json
+++ b/config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tophat/eslint-config",
     "version": "6.0.2",
-    "description": "Top Hat's shareable eslint configuration",
+    "description": "Top Hat's shareable eslint configuration.",
     "publishConfig": {
         "registry": "https://registry.npmjs.org/"
     },


### PR DESCRIPTION
BREAKING CHANGE: Since we are setting the @tanstack/query/prefer-query-object-syntax, this will require changes to your code that satisfy the rule before CI will pass. You will no longer be able to skip these changes.

feat: use package.json export maps for rule subsets

BREAKING CHANGE: The internals of @tophat/eslint-config have been refactored to better support a build step in the @tophat/eslint-config project. If you are using the default @tophat/eslint-config config in your eslint configuration file, there is no impact to you. However, if you specify individual subsets, for example, @tophat/eslint-config/jest then you must use tooling that supports the package.json exports map format. Most modern tooling supports this.