### PR TITLE
feat: add prefer-non-default-react-imports rule

### DIFF
--- a/plugins/eslint-plugin-import/src/index.ts
+++ b/plugins/eslint-plugin-import/src/index.ts
@@ -5,12 +5,14 @@ const config: ESLint.Plugin = {
         recommended: {
             plugins: ['@tophat/eslint-plugin-import'],
             rules: {
-                '@tophat/eslint-plugin-import/prefer-workspace-aliases': 'off',
+                '@tophat/import/prefer-workspace-aliases': 'off',
+                '@tophat/import/prefer-non-default-react-imports': 'off',
             },
         },
     },
     rules: {
         'prefer-workspace-aliases': require('./rules/prefer-workspace-aliases'),
+        'prefer-non-default-react-imports': require('./rules/prefer-non-default-react-imports'),
     },
 }
 

--- a/plugins/eslint-plugin-import/src/rules/prefer-non-default-react-imports/README.md
+++ b/plugins/eslint-plugin-import/src/rules/prefer-non-default-react-imports/README.md
@@ -1,0 +1,55 @@
+# prefer-non-default-react-imports
+
+This rule prefers `useState` syntax over `React.useState` syntax. It is auto-fixable.
+
+## Usage
+
+In your `.eslintrc.js` file:
+
+```js
+module.exports = {
+    extends: ['plugin:@tophat/eslint-plugin-import/recommended'],
+    plugins: ['@tophat/eslint-plugin-import'],
+    rules: {
+        '@tophat/import/prefer-non-default-react-imports': 'error',
+    },
+}
+```
+
+### Good
+
+```js
+import React, { useEffect } from 'react'
+
+function Component() {
+    useEffect(() => {}, [])
+}
+```
+
+### Bad
+
+```js
+import React from 'react'
+
+function Component() {
+    React.useEffect(() => {}, [])
+}
+```
+
+### Custom Methods
+
+You can override the default list of methods by setting `methods`:
+
+```js
+module.exports = {
+    extends: ['plugin:@tophat/eslint-plugin-import/recommended'],
+    plugins: ['@tophat/eslint-plugin-import'],
+    rules: {
+        '@tophat/import/prefer-non-default-react-imports': ['error', { methods: ['useEffect'] }],
+    },
+}
+```
+
+## Limitations
+
+The rule exits early if it encounters import aliases in the React import, or if there's a React type import such as `import type React from 'react'`. This is to reduce complexity of the implementation, however contributions to add better support for these scenarios is welcome.

--- a/plugins/eslint-plugin-import/src/rules/prefer-non-default-react-imports/index.ts
+++ b/plugins/eslint-plugin-import/src/rules/prefer-non-default-react-imports/index.ts
@@ -1,0 +1,171 @@
+import {
+    ASTUtils,
+    AST_NODE_TYPES,
+    ESLintUtils,
+    type TSESTree,
+} from '@typescript-eslint/utils'
+import { isIdentifier } from '@typescript-eslint/utils/dist/ast-utils'
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) => `@tophat/eslint-plugin-import/${name}`,
+)
+
+type MessageIds = 'rewrite-import' | 'rewrite-usage'
+
+type Options = [
+    {
+        methods?: string[]
+    },
+]
+
+const isMemberExpression = ASTUtils.isNodeOfType(
+    AST_NODE_TYPES.MemberExpression,
+)
+
+const isImportDefaultSpecifier = ASTUtils.isNodeOfType(
+    AST_NODE_TYPES.ImportDefaultSpecifier,
+)
+
+const isImportSpecifier = ASTUtils.isNodeOfType(AST_NODE_TYPES.ImportSpecifier)
+
+const rule = createRule<Options, MessageIds>({
+    name: 'prefer-non-default-react-imports',
+    meta: {
+        docs: {
+            description:
+                'Do not use the default React import, instead be explicit about imports.',
+            recommended: 'error',
+        },
+        messages: {
+            'rewrite-import': 'Your React import should contain: {{methods}}.',
+            'rewrite-usage': 'Rewrite React.{{method}} as {{method}}.',
+        },
+        type: 'suggestion',
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    methods: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                        },
+                        additionalProperties: false,
+                    },
+                },
+            },
+        ],
+        fixable: 'code',
+    },
+    defaultOptions: [
+        {
+            methods: [
+                'useCallback',
+                'useContext',
+                'useDebugValue',
+                'useDeferredValue',
+                'useEffect',
+                'useId',
+                'useImperativeHandle',
+                'useInsertionEffect',
+                'useLayoutEffect',
+                'useMemo',
+                'useReducer',
+                'useRef',
+                'useState',
+                'useSyncExternalStore',
+                'useTransition',
+            ],
+        },
+    ],
+    create(context) {
+        const methodSet = new Set(
+            context.options[0]?.methods ?? rule.defaultOptions[0].methods ?? [],
+        )
+
+        let reactImportDeclaration: TSESTree.ImportDeclaration | undefined
+        const methodsUsed: Set<string> = new Set()
+
+        return {
+            ImportDeclaration(node) {
+                // Only run on React imports and skip type-only imports (too much complexity with type imports)
+                if (node.source.value !== 'react' || node.importKind === 'type')
+                    return
+                reactImportDeclaration ??= node
+            },
+            CallExpression(node) {
+                // We're only interested in member expressions of the form React.<method>
+                if (
+                    !isMemberExpression(node.callee) ||
+                    !isIdentifier(node.callee.object) ||
+                    !isIdentifier(node.callee.property) ||
+                    node.callee.object.name !== 'React' ||
+                    !methodSet.has(node.callee.property.name)
+                ) {
+                    return
+                }
+
+                const method = node.callee.property.name
+                methodsUsed.add(method)
+
+                context.report({
+                    node: node.callee,
+                    messageId: 'rewrite-usage',
+                    data: {
+                        method,
+                    },
+                    fix(fixer) {
+                        return fixer.replaceText(node.callee, method)
+                    },
+                })
+            },
+            'Program:exit'() {
+                const reactImport = reactImportDeclaration
+
+                if (!reactImport || !methodsUsed.size) return
+
+                const allMethods = new Set<string>(methodsUsed)
+                for (const specifier of reactImport.specifiers) {
+                    if (isImportSpecifier(specifier)) {
+                        if (specifier.local.name !== specifier.imported.name) {
+                            // We don't support aliases. Too much unnecessary complexity.
+                            return
+                        }
+                        if (specifier.importKind === 'type') {
+                            allMethods.add(`type ${specifier.imported.name}`)
+                        } else {
+                            allMethods.add(specifier.imported.name)
+                        }
+                    }
+                }
+
+                const parts: string[] = []
+                if (isImportDefaultSpecifier(reactImport.specifiers[0])) {
+                    parts.push('React')
+                }
+                if (allMethods.size) {
+                    parts.push(
+                        `{ ${Array.from(allMethods).sort().join(', ')} }`,
+                    )
+                }
+
+                if (!parts.length) return
+
+                const goodImport = `import ${parts.join(', ')} from 'react'`
+
+                context.report({
+                    node: reactImport,
+                    messageId: 'rewrite-import',
+                    data: {
+                        methods: Array.from(methodsUsed).sort().join(', '),
+                    },
+                    fix(fixer) {
+                        return fixer.replaceText(reactImport, goodImport)
+                    },
+                })
+            },
+        }
+    },
+})
+
+export = rule

--- a/plugins/eslint-plugin-import/src/rules/prefer-non-default-react-imports/prefer-named-react-import.test.ts
+++ b/plugins/eslint-plugin-import/src/rules/prefer-non-default-react-imports/prefer-named-react-import.test.ts
@@ -1,0 +1,136 @@
+import { ESLintUtils } from '@typescript-eslint/utils'
+
+import rule from '.'
+
+const ruleTester = new ESLintUtils.RuleTester({
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+    },
+})
+
+describe('Prefer Non-Default React Imports', () => {
+    ruleTester.run('@thm/shared-rules/prefer-non-default-react-imports', rule, {
+        valid: [
+            {
+                code: [
+                    "import React, { useState } from 'react'",
+                    'const [x, setX] = useState(false)',
+                ].join('\n'),
+            },
+            {
+                code: [
+                    "import { useState } from 'react'",
+                    'const [x, setX] = useState(false)',
+                ].join('\n'),
+            },
+            {
+                code: [
+                    "import { useState, useEffect, useRef } from 'react'",
+                    'const [x, setX] = useState(false)',
+                    'const r = useRef()',
+                ].join('\n'),
+            },
+            {
+                // we don't apply the rule when we encounter type imports
+                // too difficult for now (but we welcome contributions to add support)
+                code: [
+                    "import type React from 'react'",
+                    'const [x, setX] = useState(false)',
+                ].join('\n'),
+            },
+        ],
+        invalid: [
+            {
+                code: [
+                    "import React from 'react'",
+                    'const [x, setX] = React.useState(false)',
+                ].join('\n'),
+                output: [
+                    "import React, { useState } from 'react'",
+                    'const [x, setX] = useState(false)',
+                ].join('\n'),
+                errors: [
+                    {
+                        messageId: 'rewrite-import',
+                        data: {
+                            methods: 'useState',
+                        },
+                    },
+                    {
+                        messageId: 'rewrite-usage',
+                        data: {
+                            method: 'useState',
+                        },
+                    },
+                ],
+            },
+            {
+                // preserves existing imports
+                code: [
+                    "import React, { useEffect } from 'react'",
+                    'const [x, setX] = React.useState(false)',
+                    'const ref = React.useRef(false)',
+                ].join('\n'),
+                output: [
+                    "import React, { useEffect, useRef, useState } from 'react'",
+                    'const [x, setX] = useState(false)',
+                    'const ref = useRef(false)',
+                ].join('\n'),
+                errors: [
+                    {
+                        messageId: 'rewrite-import',
+                        data: {
+                            methods: 'useRef, useState',
+                        },
+                    },
+                    {
+                        messageId: 'rewrite-usage',
+                        data: {
+                            method: 'useState',
+                        },
+                    },
+                    {
+                        messageId: 'rewrite-usage',
+                        data: {
+                            method: 'useRef',
+                        },
+                    },
+                ],
+            },
+
+            // Custom methods
+            {
+                code: [
+                    "import React from 'react'",
+                    'const x = React.memo()',
+                ].join('\n'),
+                output: [
+                    "import React, { memo } from 'react'",
+                    'const x = memo()',
+                ].join('\n'),
+                options: [
+                    {
+                        methods: ['memo'],
+                    },
+                ],
+                errors: [
+                    {
+                        messageId: 'rewrite-import',
+                        data: {
+                            methods: 'memo',
+                        },
+                    },
+                    {
+                        messageId: 'rewrite-usage',
+                        data: {
+                            method: 'memo',
+                        },
+                    },
+                ],
+            },
+        ],
+    })
+})


### PR DESCRIPTION
# prefer-non-default-react-imports

This rule prefers `useState` syntax over `React.useState` syntax. It is auto-fixable.

## Usage

In your `.eslintrc.js` file:

```js
module.exports = {
    extends: ['plugin:@tophat/eslint-plugin-import/recommended'],
    plugins: ['@tophat/eslint-plugin-import'],
    rules: {
        '@tophat/import/prefer-non-default-react-imports': 'error',
    },
}
```

### Good

```js
import React, { useEffect } from 'react'

function Component() {
    useEffect(() => {}, [])
}
```

### Bad

```js
import React from 'react'

function Component() {
    React.useEffect(() => {}, [])
}
```

### Custom Methods

You can override the default list of methods by setting `methods`:

```js
module.exports = {
    extends: ['plugin:@tophat/eslint-plugin-import/recommended'],
    plugins: ['@tophat/eslint-plugin-import'],
    rules: {
        '@tophat/import/prefer-non-default-react-imports': ['error', { methods: ['useEffect'] }],
    },
}
```

## Limitations

The rule exits early if it encounters import aliases in the React import, or if there's a React type import such as `import type React from 'react'`. This is to reduce complexity of the implementation, however contributions to add better support for these scenarios is welcome.
