### PR TITLE
fix: ignore no-confusing-void-expression as it changes code behaviour

### DIFF
--- a/config/src/base/index.ts
+++ b/config/src/base/index.ts
@@ -124,6 +124,7 @@ const rules: ESLint.ConfigData['rules'] = {
         'error',
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
     ],
+    // Disabled to prevent auto linting from changing code behaviour of ambigious return types
     '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-duplicate-enum-values': 'warn',
     '@typescript-eslint/no-for-in-array': 'error',

--- a/config/src/base/index.ts
+++ b/config/src/base/index.ts
@@ -124,10 +124,7 @@ const rules: ESLint.ConfigData['rules'] = {
         'error',
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
     ],
-    '@typescript-eslint/no-confusing-void-expression': [
-        'warn',
-        { ignoreVoidOperator: true },
-    ],
+    '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-duplicate-enum-values': 'warn',
     '@typescript-eslint/no-for-in-array': 'error',
     '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',


### PR DESCRIPTION
The `no-confusing-void-expression` is causing some issues with certain ambiguous type declarations. If unaware, the auto linting may add `void` to method calls where we are expecting a return value. Since linter fixes should always be safe (no code behaviour changes), I've turned off the rule.