### PR TITLE
fix: removed no-confusing-void-expressions rule

### DIFF
--- a/config/src/base/index.ts
+++ b/config/src/base/index.ts
@@ -124,8 +124,6 @@ const rules: ESLint.ConfigData['rules'] = {
         'error',
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
     ],
-    // Disabled to prevent auto linting from changing code behaviour of ambigious return types
-    '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-duplicate-enum-values': 'warn',
     '@typescript-eslint/no-for-in-array': 'error',
     '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',


### PR DESCRIPTION
Removed the `no-confusing-void-expression` rule as the default is already `off`.