### PR TITLE
fix: disable rules to ease v9 migration

### DIFF
--- a/config/src/base/index.ts
+++ b/config/src/base/index.ts
@@ -138,6 +138,8 @@ const rules: ESLint.ConfigData['rules'] = {
     '@typescript-eslint/prefer-function-type': 'off',
     '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/array-type': 'off',
+    '@typescript-eslint/consistent-indexed-object-style': 'off',
+    '@typescript-eslint/class-literal-property-style': 'off',
 
     // no-use-before-define can cause errors with typescript concepts, like types or enums
     'no-use-before-define': 'off',


### PR DESCRIPTION
NOTE: Disable @typescript-eslint/consistent-indexed-object-style and @typescript-eslint/class-literal-property-style